### PR TITLE
Edit extension settings, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ Configuration
 -----
 
 Copy app/config/parameters.yml.dist to app/config/parameters.yml and setup the configuration.
-Ensure you have a proper ssh key to your github account configured (no passphrase).
+The development version of the translation tool will create forks and perform pull requests to github.com. 
+To prevent these temporary repositories mix with your normal repositories, you have to setup a second github account for testing purposes.
+Ensure you have a proper ssh key to your github test account configured (no passphrase).
 
 http://sampreshan.svashishtha.com/2012/05/20/quicktip-github-multiple-accounts-access-with-ssh/
+
+For your default GitHub account you can use the `Host github.com`, while using e.g. `Host translationtesting.github.com` 
+for your test account. This last host should be configured in the parameters.yml of your local translation tool.
 
 Production setup
 ----------------

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,6 +47,7 @@ parameters:
     # GitHub url
     # you can change this on a development environment to setup a second ssh key for a second git account without
     # messing up your environment - http://sampreshan.svashishtha.com/2012/05/20/quicktip-github-multiple-accounts-access-with-ssh/
+    # Use e.g. Host justadomain.github.com for the second git account and Host github.com for your default account
     git_hub_url: github.com
 
     # Default locale. (there is just english)

--- a/src/org/dokuwiki/translatorBundle/Command/PatchFormatCommand.php
+++ b/src/org/dokuwiki/translatorBundle/Command/PatchFormatCommand.php
@@ -14,7 +14,7 @@ class PatchFormatCommand extends ContainerAwareCommand {
 
     protected function configure() {
         $this->setName('dokuwiki:updateLanguages')
-            ->setDescription('Updates all language information from local repository');
+            ->setDescription('Updates all language information from local repository. Refreshes the cached translation objects');
 
     }
 

--- a/src/org/dokuwiki/translatorBundle/Command/UpdateLanguagesCommand.php
+++ b/src/org/dokuwiki/translatorBundle/Command/UpdateLanguagesCommand.php
@@ -10,7 +10,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PatchFormatCommand extends ContainerAwareCommand {
+class UpdateLanguagesCommand extends ContainerAwareCommand {
 
     protected function configure() {
         $this->setName('dokuwiki:updateLanguages')

--- a/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
+++ b/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
@@ -45,7 +45,7 @@ class ExtensionController extends Controller implements InitializableController 
 
         $options['type'] = $type;
         $options['validation_groups'] = array('Default', $type);
-        $options['action'] = RepositoryCreateType::$ACTION_CREATE;
+        $options['action'] = RepositoryCreateType::ACTION_CREATE;
         $form = $this->createForm(new RepositoryCreateType(), $repository, $options);
 
         if ($request->isMethod('POST')) {
@@ -220,7 +220,7 @@ class ExtensionController extends Controller implements InitializableController 
 
         $options['type'] = $type;
         $options['validation_groups'] = array('Default', $type);
-        $options['action'] = RepositoryCreateType::$ACTION_EDIT;
+        $options['action'] = RepositoryCreateType::ACTION_EDIT;
         $form = $this->createForm(new RepositoryCreateType(), $repository, $options);
 
         if ($request->isMethod('POST')) {

--- a/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
+++ b/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
@@ -5,11 +5,13 @@ namespace org\dokuwiki\translatorBundle\Controller;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\NoResultException;
 use org\dokuwiki\translatorBundle\Entity\RepositoryEntityRepository;
+use org\dokuwiki\translatorBundle\Form\RepositoryEditType;
 use org\dokuwiki\translatorBundle\Services\Mail\MailService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use org\dokuwiki\translatorBundle\Entity\RepositoryEntity;
 use org\dokuwiki\translatorBundle\Form\RepositoryCreateType;
+use org\dokuwiki\translatorBundle\Form\RepositoryRequestEditType;
 
 class ExtensionController extends Controller implements InitializableController {
 
@@ -43,6 +45,7 @@ class ExtensionController extends Controller implements InitializableController 
 
         $options['type'] = $type;
         $options['validation_groups'] = array('Default', $type);
+        $options['action'] = RepositoryCreateType::$ACTION_CREATE;
         $form = $this->createForm(new RepositoryCreateType(), $repository, $options);
 
         if ($request->isMethod('POST')) {
@@ -59,7 +62,7 @@ class ExtensionController extends Controller implements InitializableController 
         return $this->render('dokuwikiTranslatorBundle:Extension:add.html.twig', $data);
     }
 
-    private function addExtension(RepositoryEntity &$repository) {
+    private function addExtension(RepositoryEntity $repository) {
         $api = $this->get('doku_wiki_repository_api');
 
         $api->mergeExtensionInfo($repository);
@@ -134,5 +137,121 @@ class ExtensionController extends Controller implements InitializableController 
         $data['englishreadonly'] = $this->getRequest()->query->has('englishreadonly');
 
         return $this->render('dokuwikiTranslatorBundle:Default:show.html.twig', $data);
+    }
+
+    /**
+     * Show settings and request unique url for edit form of extension configuration
+     *
+     * @param string $type
+     * @param string $name
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function settingsAction($type, $name, Request $request) {
+        $data = array();
+
+        try {
+            $repository = $this->repositoryRepository->getRepository($type, $name);  // get not waiting repos TODO only for form
+        } catch (NoResultException $e) {
+            return $this->redirect($this->generateUrl('dokuwiki_translator_homepage'));
+        }
+
+        $data['urlsent'] = false;
+        if($repository->getState() !== RepositoryEntity::$STATE_WAITING_FOR_APPROVAL) {
+            $options['type'] = $type;
+            $options['validation_groups'] = array('Default', $type);
+            $form = $this->createForm(new RepositoryRequestEditType(), $repository, $options);
+
+            if ($request->isMethod('POST')) {
+                $form->bind($request);
+                if ($form->isValid()) {
+                    $this->createAndSentEditKey($repository);
+                    $data['urlsent'] = true;
+                }
+            }
+            $data['form'] = $form->createView();
+        }
+
+        $data['repository'] = $repository;
+        return $this->render('dokuwikiTranslatorBundle:Extension:settings.html.twig', $data);
+
+    }
+
+    private function createAndSentEditKey(RepositoryEntity $repository) {
+        $repository->setActivationKey($this->generateActivationKey($repository));
+        $entityManager = $this->getDoctrine()->getManager();
+        $entityManager->merge($repository);
+        $entityManager->flush();
+
+        // FIXME replace with mail service
+        $message = \Swift_Message::newInstance();
+        $message->setSubject('Edit ' . $repository->getType() . ' settings in DokuWiki Translation Tool');
+        $message->setTo($repository->getEmail());
+        $message->setFrom($this->container->getParameter('mailer_from'));
+        $data = array(
+            'repository' => $repository,
+        );
+        $message->setBody($this->renderView('dokuwikiTranslatorBundle:Mail:extensionEditUrl.txt.twig', $data));
+        $this->get('mailer')->send($message);
+    }
+
+    /**
+     * Edit form of extension configuration
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $key
+     * @param Request $request
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse|\Symfony\Component\HttpFoundation\Response
+     */
+    public function editAction($type, $name, $key, Request $request) {
+        $data = array();
+
+        try {
+            $repository = $this->repositoryRepository->getRepositoryByNameAndEditKey($type, $name, $key);
+        } catch (NoResultException $e) {
+            return $this->redirect($this->generateUrl('dokuwiki_translator_homepage'));
+        }
+
+        $originalvalues = array(
+            'url' => $repository->getUrl(),
+            'branch' => $repository->getBranch()
+        );
+
+        $options['type'] = $type;
+        $options['validation_groups'] = array('Default', $type);
+        $options['action'] = RepositoryCreateType::$ACTION_EDIT;
+        $form = $this->createForm(new RepositoryCreateType(), $repository, $options);
+
+        if ($request->isMethod('POST')) {
+            $form->bind($request);
+            if ($form->isValid()) {
+                $this->updateExtension($repository, $originalvalues);
+
+                $param['type'] = $type;
+                $param['name'] = $name;
+                return $this->redirect($this->generateUrl('dokuwiki_translator_extension_settings', $param));
+            }
+        }
+
+        $data['repository'] = $repository;
+        $data['form'] = $form->createView();
+        return $this->render('dokuwikiTranslatorBundle:Extension:edit.html.twig', $data);
+    }
+
+    private function updateExtension(RepositoryEntity $repositoryEntity, $originalvalues) {
+        $repositoryEntity->setLastUpdate(0);
+        $repositoryEntity->setActivationKey('');
+        $entityManager = $this->getDoctrine()->getManager();
+        $entityManager->merge($repositoryEntity);
+        $entityManager->flush();
+
+        $changed = $originalvalues['branch'] !== $repositoryEntity->getBranch()
+                || $originalvalues['url'] !== $repositoryEntity->getUrl();
+
+        if($changed) {
+            $repository = $this->get('repository_manager')->getRepository($repositoryEntity);
+            $repository->deleteRepository();
+        }
     }
 }

--- a/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
+++ b/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
@@ -5,7 +5,6 @@ namespace org\dokuwiki\translatorBundle\Controller;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\NoResultException;
 use org\dokuwiki\translatorBundle\Entity\RepositoryEntityRepository;
-use org\dokuwiki\translatorBundle\Form\RepositoryEditType;
 use org\dokuwiki\translatorBundle\Services\Mail\MailService;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,6 +61,11 @@ class ExtensionController extends Controller implements InitializableController 
         return $this->render('dokuwikiTranslatorBundle:Extension:add.html.twig', $data);
     }
 
+    /**
+     * Stores data of new extension
+     *
+     * @param RepositoryEntity $repository
+     */
     private function addExtension(RepositoryEntity $repository) {
         $api = $this->get('doku_wiki_repository_api');
 
@@ -177,6 +181,11 @@ class ExtensionController extends Controller implements InitializableController 
 
     }
 
+    /**
+     * Store edit key and sent one-time edit url
+     *
+     * @param RepositoryEntity $repository
+     */
     private function createAndSentEditKey(RepositoryEntity $repository) {
         $repository->setActivationKey($this->generateActivationKey($repository));
         $entityManager = $this->getDoctrine()->getManager();
@@ -239,15 +248,21 @@ class ExtensionController extends Controller implements InitializableController 
         return $this->render('dokuwikiTranslatorBundle:Extension:edit.html.twig', $data);
     }
 
-    private function updateExtension(RepositoryEntity $repositoryEntity, $originalvalues) {
+    /**
+     * Stores updated extension data, and delete cloned repository if obsolete
+     *
+     * @param RepositoryEntity $repositoryEntity
+     * @param array $originalValues
+     */
+    private function updateExtension(RepositoryEntity $repositoryEntity, $originalValues) {
         $repositoryEntity->setLastUpdate(0);
         $repositoryEntity->setActivationKey('');
         $entityManager = $this->getDoctrine()->getManager();
         $entityManager->merge($repositoryEntity);
         $entityManager->flush();
 
-        $changed = $originalvalues['branch'] !== $repositoryEntity->getBranch()
-                || $originalvalues['url'] !== $repositoryEntity->getUrl();
+        $changed = $originalValues['branch'] !== $repositoryEntity->getBranch()
+                || $originalValues['url'] !== $repositoryEntity->getUrl();
 
         if($changed) {
             $repository = $this->get('repository_manager')->getRepository($repositoryEntity);

--- a/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
+++ b/src/org/dokuwiki/translatorBundle/Controller/ExtensionController.php
@@ -251,7 +251,7 @@ class ExtensionController extends Controller implements InitializableController 
 
         if($changed) {
             $repository = $this->get('repository_manager')->getRepository($repositoryEntity);
-            $repository->deleteRepository();
+            $repository->deleteCloneDirectory();
         }
     }
 }

--- a/src/org/dokuwiki/translatorBundle/Entity/RepositoryEntityRepository.php
+++ b/src/org/dokuwiki/translatorBundle/Entity/RepositoryEntityRepository.php
@@ -8,6 +8,9 @@ use Doctrine\ORM\Query;
 
 class RepositoryEntityRepository extends  EntityRepository {
 
+    /**
+     * @return RepositoryEntity
+     */
     public function getCoreRepository() {
         $query = $this->getEntityManager()->createQuery(
             'SELECT repository
@@ -23,6 +26,7 @@ class RepositoryEntityRepository extends  EntityRepository {
      * @param string $type
      * @param string $name
      * @return RepositoryEntity
+     *
      * @throws \Doctrine\ORM\NoResultException
      */
     public function getRepository($type, $name) {
@@ -35,6 +39,10 @@ class RepositoryEntityRepository extends  EntityRepository {
         return $repository;
     }
 
+    /**
+     * @param $language
+     * @return array
+     */
     public function getCoreRepositoryInformation($language) {
         $query = $this->getEntityManager()->createQuery(
             'SELECT stats.completionPercent, repository.displayName, repository.state, repository.englishReadonly
@@ -58,6 +66,10 @@ class RepositoryEntityRepository extends  EntityRepository {
         }
     }
 
+    /**
+     * @param $language
+     * @return array
+     */
     public function getExtensionRepositoryInformation($language) {
         $query = $this->getEntityManager()->createQuery('
             SELECT stats.completionPercent, repository.name, repository.type, repository.displayName, repository.state, repository.englishReadonly
@@ -82,14 +94,27 @@ class RepositoryEntityRepository extends  EntityRepository {
         }
     }
 
+    /**
+     * @return array
+     */
     public function getCoreTranslation() {
         return $this->getTranslation(RepositoryEntity::$TYPE_CORE, 'dokuwiki');
     }
 
+    /**
+     * @param $type
+     * @param $name
+     * @return array
+     */
     public function getExtensionTranslation($type, $name) {
         return $this->getTranslation($type, $name);
     }
 
+    /**
+     * @param $type
+     * @param $name
+     * @return array
+     */
     private function getTranslation($type, $name) {
         $query = $this->getEntityManager()->createQuery('
         SELECT repository, translations, lang
@@ -106,7 +131,12 @@ class RepositoryEntityRepository extends  EntityRepository {
         return $query->getSingleResult();
     }
 
-
+    /**
+     * @param $type
+     * @param $name
+     * @param $activationKey
+     * @return \org\dokuwiki\translatorBundle\Entity\RepositoryEntity
+     */
     public function getRepositoryByNameAndActivationKey($type, $name, $activationKey) {
         $query = $this->getEntityManager()->createQuery(
             'SELECT repository
@@ -123,6 +153,12 @@ class RepositoryEntityRepository extends  EntityRepository {
         return $query->getSingleResult();
     }
 
+    /**
+     * @param $maxAge
+     * @param $maxResults
+     * @param $maxErrors
+     * @return \org\dokuwiki\translatorBundle\Entity\RepositoryEntity[]
+     */
     public function getRepositoriesToUpdate($maxAge, $maxResults, $maxErrors) {
         $query = $this->getEntityManager()->createQuery(
             'SELECT repository

--- a/src/org/dokuwiki/translatorBundle/Entity/RepositoryEntityRepository.php
+++ b/src/org/dokuwiki/translatorBundle/Entity/RepositoryEntityRepository.php
@@ -132,23 +132,52 @@ class RepositoryEntityRepository extends  EntityRepository {
     }
 
     /**
-     * @param $type
-     * @param $name
-     * @param $activationKey
+     * Returns repository if waiting for approval and the key matches
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $activationKey
      * @return \org\dokuwiki\translatorBundle\Entity\RepositoryEntity
      */
     public function getRepositoryByNameAndActivationKey($type, $name, $activationKey) {
+        return $this->getRepositoryByNameAndKey($type, $name, $activationKey, $activation = true);
+    }
+
+    /**
+     * Returns editable repository, if is not waiting for approval and the key matches
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $editKey
+     * @return \org\dokuwiki\translatorBundle\Entity\RepositoryEntity
+     */
+    public function getRepositoryByNameAndEditKey($type, $name, $editKey) {
+        return $this->getRepositoryByNameAndKey($type, $name, $editKey, $activation = false);
+    }
+
+    /**
+     * Returns repository for matching edit or activation key
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $key
+     * @param bool $activation
+     * @return mixed
+     */
+    private function getRepositoryByNameAndKey($type, $name, $key, $activation = true) {
+        $operator = ($activation ? '=' : '<>');
+
         $query = $this->getEntityManager()->createQuery(
-            'SELECT repository
+            "SELECT repository
              FROM dokuwikiTranslatorBundle:RepositoryEntity repository
              WHERE repository.type = :type
              AND repository.name = :name
              AND repository.activationKey = :key
-             AND repository.state = :state'
+             AND repository.state $operator :state "
         );
         $query->setParameter('type', $type);
         $query->setParameter('name', $name);
-        $query->setParameter('key', $activationKey);
+        $query->setParameter('key', $key);
         $query->setParameter('state', RepositoryEntity::$STATE_WAITING_FOR_APPROVAL);
         return $query->getSingleResult();
     }

--- a/src/org/dokuwiki/translatorBundle/Form/RepositoryCreateType.php
+++ b/src/org/dokuwiki/translatorBundle/Form/RepositoryCreateType.php
@@ -9,12 +9,12 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class RepositoryCreateType extends AbstractType {
 
-    public static $ACTION_CREATE = 'create';
-    public static $ACTION_EDIT = 'edit';
+    const ACTION_CREATE = 'create';
+    const ACTION_EDIT = 'edit';
 
 
     public function buildForm(FormBuilderInterface $builder, array $options) {
-        if($options['action'] == RepositoryCreateType::$ACTION_CREATE) {
+        if($options['action'] == RepositoryCreateType::ACTION_CREATE) {
             $builder->add('name', 'text', array('label' => ucfirst($options['type']) . ' name'));
         }
         $builder->add('email', 'text', array('label' => 'E-mail'));
@@ -38,7 +38,7 @@ class RepositoryCreateType extends AbstractType {
             array(
                 'type' => RepositoryEntity::$TYPE_PLUGIN,
                 'validation_groups' => array(RepositoryEntity::$TYPE_PLUGIN),
-                'action' => RepositoryCreateType::$ACTION_CREATE
+                'action' => RepositoryCreateType::ACTION_CREATE
             )
         );
     }

--- a/src/org/dokuwiki/translatorBundle/Form/RepositoryCreateType.php
+++ b/src/org/dokuwiki/translatorBundle/Form/RepositoryCreateType.php
@@ -9,8 +9,14 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class RepositoryCreateType extends AbstractType {
 
+    public static $ACTION_CREATE = 'create';
+    public static $ACTION_EDIT = 'edit';
+
+
     public function buildForm(FormBuilderInterface $builder, array $options) {
-        $builder->add('name', 'text', array('label' => ucfirst($options['type']) . ' name'));
+        if($options['action'] == RepositoryCreateType::$ACTION_CREATE) {
+            $builder->add('name', 'text', array('label' => ucfirst($options['type']) . ' name'));
+        }
         $builder->add('email', 'text', array('label' => 'E-mail'));
         $builder->add('url', 'text', array('label' => 'Git clone url'));
         $builder->add('branch', 'text', array('label' => 'Main branch'));
@@ -31,7 +37,8 @@ class RepositoryCreateType extends AbstractType {
         $resolver->setDefaults(
             array(
                 'type' => RepositoryEntity::$TYPE_PLUGIN,
-                'validation_groups' => array(RepositoryEntity::$TYPE_PLUGIN)
+                'validation_groups' => array(RepositoryEntity::$TYPE_PLUGIN),
+                'action' => RepositoryCreateType::$ACTION_CREATE
             )
         );
     }

--- a/src/org/dokuwiki/translatorBundle/Form/RepositoryRequestEditType.php
+++ b/src/org/dokuwiki/translatorBundle/Form/RepositoryRequestEditType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace org\dokuwiki\translatorBundle\Form;
+
+
+
+use org\dokuwiki\translatorBundle\Entity\RepositoryEntity;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class RepositoryRequestEditType extends AbstractType {
+
+    public function buildForm(FormBuilderInterface $builder, array $options) {
+        $builder->add('captcha', 'captcha');
+    }
+
+    /**
+     * Returns the name of this type.
+     *
+     * @return string The name of this type
+     */
+    public function getName() {
+        return 'requesteditrepository';
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver) {
+        $resolver->setDefaults(
+            array(
+                'type' => RepositoryEntity::$TYPE_PLUGIN,
+                'validation_groups' => array(RepositoryEntity::$TYPE_PLUGIN)
+            )
+        );
+    }
+}

--- a/src/org/dokuwiki/translatorBundle/Resources/config/routing.yml
+++ b/src/org/dokuwiki/translatorBundle/Resources/config/routing.yml
@@ -20,6 +20,18 @@ dokuwiki_translator_extension_activate:
     requirements:
         type: plugin|template
 
+dokuwiki_translator_extension_settings:
+    pattern:  /{type}/{name}/settings
+    defaults: { _controller: dokuwikiTranslatorBundle:Extension:settings}
+    requirements:
+        type: plugin|template
+
+dokuwiki_translator_extension_edit:
+    pattern:  /{type}/{name}/edit/{key}
+    defaults: { _controller: dokuwikiTranslatorBundle:Extension:edit}
+    requirements:
+        type: plugin|template
+
 dokuwiki_translate:
     pattern:  /translate/dokuwiki
     defaults: { _controller: dokuwikiTranslatorBundle:Translation:translateCore }

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Default/show.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Default/show.html.twig
@@ -129,11 +129,17 @@
                     </tbody>
                 </table>
             </div>
-            <div class="span12">
+            <div class="span8">
                 <p>
                     <span class="label label-info">Note</span>
                     These statistics were last updated at {{ repository.lastupdate|date("m/d/Y") }}</p>
             </div>
+            {% if repository.type != 'core'%}
+            <div class="span4 text-right">
+                <p>
+                    <a href="{{ path("dokuwiki_translator_extension_settings", {"type": repository.type, "name":repository.name }) }}">show settings</a> for {{ repository.displayName|capitalize }}
+            </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Extension/add.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Extension/add.html.twig
@@ -45,32 +45,9 @@
             </div>
 
             <div class="span6">
-                <b>Notes</b>
-                <ul>
-                    <li>Your {{ form.vars.data.type }} needs to be available in a public Git repository</li>
-                    <li>Your {{ form.vars.data.type }} has to be listed on the
-                        {%  if form.vars.data.type == 'plugin' %}
-                            <a href="https://www.dokuwiki.org/plugins">official plugins list</a>
-                        {% else %}
-                            <a href="https://www.dokuwiki.org/template">official template list</a>
-                        {% endif %}</li>
-                    <li>The repository clone URL must start with <em>ssh://</em>,
-                        <em>http://</em> <em>https://</em> or <em>git://</em>.
-                        Unfortunately not accepted: <em>git@...</em>. The URL ends normally with <em>.git</em></li>
-                    <li>The {{ form.vars.data.type }} name is the name of your {{ form.vars.data.type }} folder (lower case, no special chars)</li>
-                    <li>If Readonly, submitting the English translations via this tool is disabled.</li>
-                    <li>
-                        It needs to use the <a href="https://www.dokuwiki.org/devel:localization">DokuWiki localization
-                            functions</a>
-                        with the following limitations:
-                        <ul>
-                            <li>No use of nested arrays in the $lang array except for the js sub array</li>
-                            <li>No code execution in your language files</li>
-                            <li>Only single line array value assignments</li>
-                            <li>Comments will be removed automatically in translations</li>
-                        </ul>
-                    </li>
-                </ul>
+                {% include 'dokuwikiTranslatorBundle:Template:explanation.html.twig'
+                    with { 'showname': true }
+                %}
             </div>
         </div>
     </div>

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Extension/edit.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Extension/edit.html.twig
@@ -1,0 +1,60 @@
+{% extends 'dokuwikiTranslatorBundle:Default:index.html.twig' %}
+
+{% block content %}
+    <ul class="breadcrumb">
+        <li><a href="{{ path('dokuwiki_translator_homepage') }}">Home</a> <span class="divider">/</span></li>
+        <li>
+            {% if repository.type == 'core' %}
+                <a href="{{ path("dokuwiki_translator_show") }} ">{{ repository.displayName|capitalize }}</a>
+            {% else %}
+                <a href="{{ path("dokuwiki_translator_show_extension", {'type': repository.type, 'name': repository.name}) }} ">{{ repository.displayName|capitalize }}</a>
+            {% endif %}
+            <span class="divider">/</span>
+        </li>
+        <li class="active">Edit Settings</li>
+    </ul>
+    <div class="container">
+        <div class="row">
+            <div class="span12">
+                <div class="page-header">
+                    <h1>Edit {{ form.vars.data.type|capitalize }} Settings</h1>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="span6">
+                <p>
+                    Here you can edit the settings of your {{ form.vars.data.type }}. You can
+                    use this edit URL one time. After a succesfull save of this form you need to
+                    request a new edit URL for eventually other edits.
+                </p>
+
+                {% if errors is defined %}
+                    <ul>
+                        {% for error in errors %}
+                            <li>{{ error.message }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                <form action="{{ path('dokuwiki_translator_extension_edit', {'type': repository.type, 'name': repository.name, 'key': repository.activationKey}) }}" class="form-horizontal" method="post">
+                    {{ form_widget(form) }}
+
+                    <div class="controls">
+                        <input type="submit" class="btn btn-primary" value="Update my {{ form.vars.data.type }}!"/>
+                        <a href="{{ path('dokuwiki_translator_extension_settings', {'type': repository.type, 'name': repository.name}) }}" class="btn">
+                            Abort
+                        </a>
+                    </div>
+                </form>
+            </div>
+            <div class="span6">
+                {% include 'dokuwikiTranslatorBundle:Template:explanation.html.twig'
+                    with { 'showname': false }
+                %}
+            </div>
+        </div>
+    </div>
+
+
+
+{% endblock %}

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Extension/edit.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Extension/edit.html.twig
@@ -26,7 +26,7 @@
                 <p>
                     Here you can edit the settings of your {{ form.vars.data.type }}. You can
                     use this edit URL one time. After a succesfull save of this form you need to
-                    request a new edit URL for eventually other edits.
+                    request a new edit URL for any additional edits.
                 </p>
 
                 {% if errors is defined %}

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Extension/settings.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Extension/settings.html.twig
@@ -1,0 +1,73 @@
+{% extends 'dokuwikiTranslatorBundle:Default:index.html.twig' %}
+
+{% block content %}
+    <ul class="breadcrumb">
+        <li><a href="{{ path('dokuwiki_translator_homepage') }}">Home</a> <span class="divider">/</span></li>
+        <li>
+            {% if repository.type == 'core' %}
+                <a href="{{ path("dokuwiki_translator_show") }} ">{{ repository.displayName|capitalize }}</a>
+            {% else %}
+                <a href="{{ path("dokuwiki_translator_show_extension", {'type': repository.type, 'name': repository.name}) }} ">{{ repository.displayName|capitalize }}</a>
+            {% endif %}
+            <span class="divider">/</span>
+        </li>
+        <li class="active">Settings</li>
+    </ul>
+    <div class="container">
+        <div class="row">
+            <div class="span12">
+                <div class="page-header">
+                    <h1>{{ repository.type|capitalize }} Settings</h1>
+                </div>
+            </div>
+            {% if urlsent %}
+            <div class="span12">
+                <div class="alert alert-success">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    An one-time edit url is sent to your last provided e-mail address.
+                </div>
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="row">
+            <div class="span8">
+                {% include 'dokuwikiTranslatorBundle:Template:box.html.twig' %}
+            </div>
+        </div>
+        {% if not urlsent and repository.state != 'waiting' %}
+        <div class="row">
+            <div class="span6">
+                <h2>Request One-time Edit</h2>
+                <p>
+                    For modifying the e-mail, git clone URL, branch or English read-only setting you have to request
+                    an one-time edit URL. This URL is sent to the earlier provided e-mail address.
+                </p>
+
+                {% if errors is defined %}
+                    <ul>
+                        {% for error in errors %}
+                            <li>{{ error.message }}</li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+                <form action="{{ path('dokuwiki_translator_extension_settings', {'type': repository.type, 'name': repository.name}) }}" class="form-horizontal" method="post">
+                    {{ form_widget(form) }}
+
+                    <div class="controls">
+                        <input type="submit" class="btn btn-primary" value="Request Setting Edit URL"/>
+                        {#{% if repository.type == 'core' %}#}
+                            {#<a href="{{ path("dokuwiki_translator_show") }} " class="btn">Abort</a>#}
+                        {#{% else %}#}
+                            {#<a href="{{ path("dokuwiki_translator_show_extension", {'type': repository.type, 'name': repository.name}) }} " class="btn">Abort</a>#}
+                        {#{% endif %}#}
+                    </div>
+                </form>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+
+
+{% endblock %}

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Extension/settings.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Extension/settings.html.twig
@@ -56,11 +56,6 @@
 
                     <div class="controls">
                         <input type="submit" class="btn btn-primary" value="Request Setting Edit URL"/>
-                        {#{% if repository.type == 'core' %}#}
-                            {#<a href="{{ path("dokuwiki_translator_show") }} " class="btn">Abort</a>#}
-                        {#{% else %}#}
-                            {#<a href="{{ path("dokuwiki_translator_show_extension", {'type': repository.type, 'name': repository.name}) }} " class="btn">Abort</a>#}
-                        {#{% endif %}#}
                     </div>
                 </form>
             </div>

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Mail/extensionEditUrl.txt.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Mail/extensionEditUrl.txt.twig
@@ -1,0 +1,14 @@
+{% extends 'dokuwikiTranslatorBundle:Mail:main.txt.twig' %}
+
+{% block content %}
+An url to the edit form for the settings of the {{ repository.displayName }} has been requested
+from the DokuWiki translation tool. This url can be used for an one-time edit of the settings.
+
+To go to the form just click on the following link:
+
+{{ url('dokuwiki_translator_extension_edit', {'type': repository.type, 'name': repository.name, 'key': repository.activationKey}) }}
+
+
+Note that this e-mail is sent to the address that was filled in before in the {{ repository.type }} settings in the Translation Tool.
+If you didn't expect this message please contact admin@dokuwiki.org.
+{% endblock %}

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Template/box.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Template/box.html.twig
@@ -27,4 +27,61 @@
         <th>Tags</th>
         <td>{{ repository.tags }}</td>
     </tr>
+    <tr>
+        <th>Popularity score</th>
+        <td>{{ repository.popularity }}</td>
+    </tr>
+    <tr>
+        <th>Git clone URL</th>
+        <td>{{ repository.url }}</td>
+    </tr>
+    <tr>
+        <th>Branch</th>
+        <td>{{ repository.branch }}</td>
+    </tr>
+    <tr>
+        <th>English&nbsp;read&#8209;only</th>
+        <td>
+            {% if repository.englishreadonly %}
+                Yes
+            {% else %}
+                No
+            {% endif %}
+        </td>
+    </tr>
+    <tr>
+        <th>Last git update</th>
+        <td>{% if repository.lastupdate == 0 %}
+                None
+            {% else %}
+                {{ repository.lastupdate|date("m/d/Y") }}</td>
+            {% endif %}
+    </tr>
+    <tr>
+        <th>State</th>
+        <td>{% if repository.state == 'waiting' %}
+                Waiting for approval
+            {% elseif repository.state == 'initialProcessing' %}
+                Approved. Now initial processing.
+            {% elseif repository.state == 'active' %}
+                Active.
+            {% elseif repository.state == 'error' %}
+                Error happened.
+            {% else %}
+                {{ repository.state }}
+            {% endif %}
+        </td>
+    </tr>
+    <tr>
+        <th>Error count</th>
+        <td>{{ repository.errorCount }}</td>
+    </tr>
+    {#<tr>#}
+        {#<th>Last stored error message</th>#}
+        {#<td>{{ repository.errorMsg }}</td>#}
+    {#</tr>#}
+    {#<tr>#}
+        {#<th>Key</th>#}
+        {#<td>{{ repository.activationKey }}</td>#}
+    {#</tr>#}
 </table>

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Template/explanation.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Template/explanation.html.twig
@@ -1,0 +1,30 @@
+<b>Notes</b>
+<ul>
+    <li>Your {{ form.vars.data.type }} needs to be available in a public Git repository</li>
+    {% if showname %}
+    <li>Your {{ form.vars.data.type }} has to be listed on the
+        {%  if form.vars.data.type == 'plugin' %}
+            <a href="https://www.dokuwiki.org/plugins">official plugins list</a>
+        {% else %}
+            <a href="https://www.dokuwiki.org/template">official template list</a>
+        {% endif %}</li>
+    {% endif %}
+    <li>The repository clone URL must start with <em>ssh://</em>,
+        <em>http://</em> <em>https://</em> or <em>git://</em>.
+        Unfortunately not accepted: <em>git@...</em>. The URL ends normally with <em>.git</em></li>
+    {% if showname %}
+        <li>The {{ form.vars.data.type }} name is the name of your {{ form.vars.data.type }} folder (lower case, no special chars)</li>
+    {% endif %}
+    <li>If Readonly, submitting the English translations via this tool is disabled.</li>
+    <li>
+        It needs to use the <a href="https://www.dokuwiki.org/devel:localization">DokuWiki localization
+            functions</a>
+        with the following limitations:
+        <ul>
+            <li>No use of nested arrays in the $lang array except for the js sub array</li>
+            <li>No code execution in your language files</li>
+            <li>Only single line array value assignments</li>
+            <li>Comments will be removed automatically in translations</li>
+        </ul>
+    </li>
+</ul>

--- a/src/org/dokuwiki/translatorBundle/Services/Language/Author.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Language/Author.php
@@ -20,8 +20,16 @@ class Author {
     }
 
     public function equals(Author $author) {
-        if (mb_strtolower($author->getName()) !== mb_strtolower($this->getName())
-            && mb_strtolower($author->getEmail()) !== mb_strtolower($this->getEmail())) return false;
+        if($author->getName() === '' && $this->name === '' ) {
+            return mb_strtolower($author->getEmail()) === mb_strtolower($this->email);
+        }
+
+        if($author->getEmail() === '' && $this->email === '' ) {
+            return mb_strtolower($author->getName()) === mb_strtolower($this->name);
+        }
+
+        if (mb_strtolower($author->getName()) !== mb_strtolower($this->name)
+            && mb_strtolower($author->getEmail()) !== mb_strtolower($this->email)) return false;
         return true;
     }
 

--- a/src/org/dokuwiki/translatorBundle/Services/Language/LanguageFileParser.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Language/LanguageFileParser.php
@@ -189,12 +189,31 @@ class LanguageFileParser {
             }
 
             $line .= "\n";
-            if(preg_match('/\* @author:? (.+?)(?: <(.*?)>)?\n/i', $line, $matches)) {
-                $this->author->add(new Author(trim($matches[1]), isset($matches[2])?trim($matches[2]):''));
+            if(preg_match('/\* @author:?[ ]+<(.*?)>\n/i', $line, $matches)) {
+                $this->author->add(new Author('', trim($matches[1])));
+                continue;
+            }elseif(preg_match('/\* @author:? (.+?)(?: <(.*?)>)?\n/i', $line, $matches)) {
+                $name = trim($matches[1]);
+                $email = '';
+                if(isset($matches[2])) {
+                    $email = trim($matches[2]);
+                } else {
+                    $nameparts = explode(" ", $name);
+                    foreach(array_reverse($nameparts) as $namepart) {
+                        $trimmed = trim($namepart);
+                        $isEmail = filter_var($trimmed, FILTER_VALIDATE_EMAIL);
+                        if($isEmail) {
+                            $name = trim(str_replace($trimmed, '', $name));
+                            $email = $trimmed;
+                            break;
+                        }
+                    }
+                }
+                $this->author->add(new Author($name, $email));
                 continue;
             }
 
-            $multilineMarker = '*';
+                $multilineMarker = '*';
             if ($this->stringStartsWith($line, $multilineMarker)) {
                 $line = substr($line, strlen($multilineMarker));
                 $line = ltrim($line, ' ');

--- a/src/org/dokuwiki/translatorBundle/Services/Language/LocalText.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Language/LocalText.php
@@ -85,8 +85,13 @@ class LocalText {
 
         /** @var Author $author */
         foreach ($authors as $author) {
-            if ($author->getName() === '') continue;
-            $authorName = $this->escapeComment($author->getName());
+            if ($author->getName() === '' && $author->getEmail() === '') continue;
+            $name = $author->getName();
+            if($name === '') {
+                $user = explode('@', $author->getEmail(), 2);
+                $name = $user[0];
+            }
+            $authorName = $this->escapeComment($name);
             $php.= " * @author $authorName";
             if ($author->getEmail() !== '') {
                 $email = $this->escapeComment($author->getEmail());

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/GitHubBehavior.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/GitHubBehavior.php
@@ -47,7 +47,7 @@ class GitHubBehavior implements RepositoryBehavior {
     }
 
     /**
-     * Fork at Github and return url of the fork
+     * Fork original repo at Github and return url of the fork
      *
      * @param RepositoryEntity $repository
      * @return string Git URL of the fork
@@ -57,7 +57,7 @@ class GitHubBehavior implements RepositoryBehavior {
     }
 
     /**
-     * Update from original and push to fork
+     * Update from original and push to fork of translate tool
      *
      * @param GitRepository $git
      * @param RepositoryEntity $repository

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/PlainBehavior.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/PlainBehavior.php
@@ -31,12 +31,19 @@ class PlainBehavior implements RepositoryBehavior {
         );
     }
 
+    /**
+     * Return url of 'origin' repository, which is the original repository given
+     *
+     * @param RepositoryEntity $repository
+     * @return string
+     */
     function createOriginURL(RepositoryEntity $repository) {
         return $repository->getUrl();
     }
 
     /**
-     * Called before a pull
+     * Update repository from remote
+     *
      * @param GitRepository $git
      * @param RepositoryEntity $repository
      * @return bool true if the repository is changed

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/RepositoryBehavior.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/RepositoryBehavior.php
@@ -10,16 +10,25 @@ interface RepositoryBehavior {
 
     function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit);
 
+    /**
+     * Return url of 'origin' repository
+     * (which can be the original repository or e.g. a fork, that is forked firstly
+     * in a translator tool account from the original)
+     *
+     * @param RepositoryEntity $repository
+     * @return string
+     */
     function createOriginURL(RepositoryEntity $repository);
 
     /**
-     * Called before a pull
+     * Update repository from remote
      *
      * @param GitRepository $git
      * @param RepositoryEntity $repository
      * @return bool true if the repository is changed
      */
     function pull(GitRepository $git, RepositoryEntity $repository);
+
 
     function isFunctional();
 

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
@@ -480,7 +480,7 @@ abstract class Repository {
     /**
      * Deletes the folder with the git repository checkout
      */
-    private function deleteRepository() {
+    public function deleteRepository() {
         $path = $this->getRepositoryPath();
         if (!file_exists($path)) return;
         $this->rrmdir($path);

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
@@ -152,12 +152,12 @@ abstract class Repository {
         //no repository exists yet
         try {
             $remote = $this->behavior->createOriginURL($this->entity);
-            $this->git = $this->gitService->createRepositoryFromRemote($remote, $this->getRepositoryPath());
+            $this->git = $this->gitService->createRepositoryFromRemote($remote, $this->getCloneDirectoryPath());
         } catch (GitCloneException $e) {
-            $this->deleteRepository();
+            $this->deleteCloneDirectory();
             throw $e;
         } catch (GitHubForkException $e) {
-            $this->deleteRepository();
+            $this->deleteCloneDirectory();
             throw $e;
         }
         return true;
@@ -167,8 +167,8 @@ abstract class Repository {
      * Try to open repository, if existing set the GitRepository object
      */
     private function openRepository() {
-        if ($this->gitService->isRepository($this->getRepositoryPath())) {
-            $this->git = $this->gitService->openRepository($this->getRepositoryPath());
+        if ($this->gitService->isRepository($this->getCloneDirectoryPath())) {
+            $this->git = $this->gitService->openRepository($this->getCloneDirectoryPath());
         }
     }
 
@@ -177,7 +177,7 @@ abstract class Repository {
      *
      * @return string
      */
-    private function getRepositoryPath() {
+    private function getCloneDirectoryPath() {
         return $this->buildBasePath() . 'repository/';
     }
 
@@ -384,7 +384,7 @@ abstract class Repository {
         $this->openRepository();
 
         // clone the local temporary git repository
-        $tmpGit = $this->gitService->createRepositoryFromRemote($this->getRepositoryPath(), $tmpDir);
+        $tmpGit = $this->gitService->createRepositoryFromRemote($this->getCloneDirectoryPath(), $tmpDir);
         // add files to local temporary git repository
         $this->applyChanges($tmpGit, $tmpDir, $update);
         // commit files to local temporary git repository
@@ -480,8 +480,8 @@ abstract class Repository {
     /**
      * Deletes the folder with the git repository checkout
      */
-    public function deleteRepository() {
-        $path = $this->getRepositoryPath();
+    public function deleteCloneDirectory() {
+        $path = $this->getCloneDirectoryPath();
         if (!file_exists($path)) return;
         $this->rrmdir($path);
     }
@@ -492,7 +492,7 @@ abstract class Repository {
      * @return bool
      */
     public function hasGit() {
-        return is_dir($this->getRepositoryPath());
+        return is_dir($this->getCloneDirectoryPath());
     }
 
     /**

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
@@ -248,9 +248,13 @@ abstract class Repository {
      */
     private function saveLanguage($translations) {
         $langFolder = $this->buildBasePath() . 'lang/';
-        if (!file_exists($langFolder)) {
-            mkdir($langFolder, 0777, true);
+
+        // delete entire folder to ensure clean up deleted files
+        if (file_exists($langFolder)) {
+            $this->rrmdir($langFolder);
         }
+
+        mkdir($langFolder, 0777, true);
 
         foreach ($translations as $langCode => $files) {
             file_put_contents("$langFolder$langCode.ser", serialize($files));
@@ -283,10 +287,16 @@ abstract class Repository {
         return file_exists($this->getLockPath());
     }
 
+    /**
+     * Set lock in base folder of repository
+     */
     private function lock() {
         touch($this->getLockPath());
     }
 
+    /**
+     * Remove the lock
+     */
     private function unlock() {
         @unlink($this->getLockPath());
     }

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
@@ -136,7 +136,7 @@ abstract class Repository {
     }
 
     /**
-     * Update local repository if already exist by pull, otherwise
+     * Update local repository if already exist by pull, otherwise create local one
      *
      * @throws GitCloneException
      * @throws GitHubForkException
@@ -154,10 +154,10 @@ abstract class Repository {
             $remote = $this->behavior->createOriginURL($this->entity);
             $this->git = $this->gitService->createRepositoryFromRemote($remote, $this->getRepositoryPath());
         } catch (GitCloneException $e) {
-            $this->delete();
+            $this->deleteRepository();
             throw $e;
         } catch (GitHubForkException $e) {
-            $this->delete();
+            $this->deleteRepository();
             throw $e;
         }
         return true;
@@ -467,12 +467,20 @@ abstract class Repository {
         if (!$changes) throw new NoLanguageFileWrittenException();
     }
 
-    private function delete() {
-        $path = $this->buildBasePath();
+    /**
+     * Deletes the folder with the git repository checkout
+     */
+    private function deleteRepository() {
+        $path = $this->getRepositoryPath();
         if (!file_exists($path)) return;
         $this->rrmdir($path);
     }
 
+    /**
+     * Check if folder with git repository checkout exists
+     *
+     * @return bool
+     */
     public function hasGit() {
         return is_dir($this->getRepositoryPath());
     }

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/RepositoryManager.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/RepositoryManager.php
@@ -83,6 +83,9 @@ class RepositoryManager {
         $this->gitHubStatus = $gitHubStatus;
     }
 
+    /**
+     * @return \org\dokuwiki\translatorBundle\Services\Repository\Repository[]
+     */
     public function getRepositoriesToUpdate() {
         $repositories = $this->findRepositoriesToUpdate();
         $result = array();
@@ -93,6 +96,9 @@ class RepositoryManager {
         return $result;
     }
 
+    /**
+     * @return \org\dokuwiki\translatorBundle\Entity\RepositoryEntity[]
+     */
     private function findRepositoriesToUpdate() {
 
         try {
@@ -104,7 +110,7 @@ class RepositoryManager {
 
     /**
      * @param RepositoryEntity $repository
-     * @return Repository
+     * @return \org\dokuwiki\translatorBundle\Services\Repository\Repository
      */
     public function getRepository(RepositoryEntity $repository) {
         $behavior = $this->getRepositoryBehavior($repository);
@@ -121,6 +127,10 @@ class RepositoryManager {
                 $this->gitService, $behavior, $this->logger, $this->mailService);
     }
 
+    /**
+     * @param RepositoryEntity $repository
+     * @return \org\dokuwiki\translatorBundle\Services\Repository\Behavior\RepositoryBehavior
+     */
     private function getRepositoryBehavior(RepositoryEntity $repository) {
         $url = $repository->getUrl();
         if (preg_match('/^(git:\/\/|https:\/\/|git@)github\.com/i', $url)) {

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/RepositoryStats.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/RepositoryStats.php
@@ -53,6 +53,11 @@ class RepositoryStats {
             $scores[$language] = $this->calcStatsForLanguage($translation);
         }
 
+        if($scores['en'] === 0 ) {
+            echo 'zero English strings available';
+            return;
+        }
+
         $max = $scores['en'];
         foreach ($scores as $language => $score) {
             $statsEntity = new LanguageStatsEntity();

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/AuthorListTest.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/AuthorListTest.php
@@ -43,4 +43,22 @@ class AuthorListTest extends \PHPUnit_Framework_TestCase {
         $this->assertTrue($list->has(new Author('name', 'email')));
         $this->assertTrue($list->has(new Author('name1', 'email1')));
     }
+
+    function testAddEmptyNameOnlyEmails() {
+        $list = new AuthorList();
+        $list->add(new Author('', 'email1'));
+        $list->add(new Author('', 'email2'));
+        $this->assertEquals(2, count($list->getAll()));
+        $this->assertTrue($list->has(new Author('', 'email1')));
+        $this->assertTrue($list->has(new Author('', 'email2')));
+    }
+
+    function testAddDifferentNamesEmptyemails() {
+        $list = new AuthorList();
+        $list->add(new Author('naam1', ''));
+        $list->add(new Author('naam2', ''));
+        $this->assertEquals(2, count($list->getAll()));
+        $this->assertTrue($list->has(new Author('naam1', '')));
+        $this->assertTrue($list->has(new Author('naam2', '')));
+    }
 }

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LanguageFileParserTest.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LanguageFileParserTest.php
@@ -189,6 +189,73 @@ class LanguageFileParserTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * handle multiple loosy defined author tags
+     */
+    function testAuthorWithoutBrackets() {
+        $parser = new LanguageFileParserTestDummy();
+        $parser->setAuthor(new AuthorList());
+        $parser->setContent("some text\n * @var string some text\n   * @author onlyemail@example.com\n*/ text");
+        $this->assertEquals(LanguageFileParser::$MODE_PHP, $parser->processMultiLineComment());
+
+        $expected = new AuthorList();
+        $expected->add(new Author('', 'onlyemail@example.com'));
+        $this->assertEquals($expected, $parser->getAuthor());
+        $this->assertEquals(' text', $parser->getContent());
+
+    }
+
+    /**
+     * handle multiple loosy defined author tags
+     */
+    function testAuthorWithoutEmail() {
+        $parser = new LanguageFileParserTestDummy();
+        $parser->setAuthor(new AuthorList());
+        $parser->setContent("some text\n * @var string some text\n   * @author    Only Name\n*/ text");
+        $this->assertEquals(LanguageFileParser::$MODE_PHP, $parser->processMultiLineComment());
+
+        $expected = new AuthorList();
+        $expected->add(new Author('Only Name', ''));
+        $this->assertEquals($expected, $parser->getAuthor());
+        $this->assertEquals(' text', $parser->getContent());
+
+    }
+
+    /**
+     * handle multiple loosy defined author tags
+     */
+    function testAuthorOnlyemailinbrackets() {
+        $parser = new LanguageFileParserTestDummy();
+        $parser->setAuthor(new AuthorList());
+        $parser->setContent("some text\n * @var string some text\n   * @author   <onlybrackets@example.com>\n*/ text");
+        $this->assertEquals(LanguageFileParser::$MODE_PHP, $parser->processMultiLineComment());
+
+        $expected = new AuthorList();
+        $expected->add(new Author('', 'onlybrackets@example.com'));
+        $this->assertEquals($expected, $parser->getAuthor());
+        $this->assertEquals(' text', $parser->getContent());
+
+    }
+
+    /**
+     * handle multiple loosy defined author tags
+     */
+    function testAuthorWithoutnameMultiple() {
+        $parser = new LanguageFileParserTestDummy();
+        $parser->setAuthor(new AuthorList());
+        $parser->setContent("some text\n * @var string some text\n   * @author onlyemail@example.com\n* @author    Only Name\n* @author <onlybrackets@example.com>\n*/ text");
+        $this->assertEquals(LanguageFileParser::$MODE_PHP, $parser->processMultiLineComment());
+
+        $expected = new AuthorList();
+        $expected->add(new Author('', 'onlyemail@example.com'));
+        $expected->add(new Author('Only Name', ''));
+        $expected->add(new Author('', 'onlybrackets@example.com'));
+        $this->assertEquals($expected, $parser->getAuthor());
+        $this->assertEquals(' text', $parser->getContent());
+
+    }
+
+
+    /**
      * handle @author with trailing semicolon (however it is invalid phpdocs syntax)
      */
     function testIssue38() {
@@ -342,7 +409,7 @@ class LanguageFileParserTest extends \PHPUnit_Framework_TestCase {
 ';
 
         $this->assertEquals($expectedheader, $parser->getHeader());
-        $this->assertEquals(18, count($parser->getAuthor()->getAll()));
+        $this->assertEquals(20, count($parser->getAuthor()->getAll()));
         $this->assertEquals(268, count($parser->getLang()));
         $this->assertEquals(41, count($parser->getLangByKey('js')));
     }
@@ -354,7 +421,7 @@ class LanguageFileParserTest extends \PHPUnit_Framework_TestCase {
         $parser->setContent($content);
         $parser->parse();
 
-        $this->assertEquals(18, count($parser->getAuthor()->getAll()));
+        $this->assertEquals(20, count($parser->getAuthor()->getAll()));
         $this->assertEquals(268, count($parser->getLang()));
         $this->assertEquals(41, count($parser->getLangByKey('js')));
     }

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LanguageFileParserTest.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LanguageFileParserTest.php
@@ -337,6 +337,8 @@ class LanguageFileParserTest extends \PHPUnit_Framework_TestCase {
  * german language file
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ *
+ * @package DokuWiki\lang\de\settings
 ';
 
         $this->assertEquals($expectedheader, $parser->getHeader());

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LocalTextTest.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LocalTextTest.php
@@ -32,7 +32,7 @@ CONTENT;
 <?php
 
 /**
- * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @license    GPL 3 (http://www.gnu.org/licenses/gpl.html)
  *
  * @author author <e@ma.il>
  */
@@ -42,7 +42,7 @@ CONTENT;
 
         $author = new AuthorList();
         $author->add(new Author('author', 'e@ma.il'));
-        $header = " *\n * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)\n *\n";
+        $header = " *\n * @license    GPL 3 (http://www.gnu.org/licenses/gpl.html)\n *\n";
         $translation = new LocalText(array('key' => 'new translated value'), LocalText::$TYPE_ARRAY, $author, $header);
         $result = $translation->render();
         $this->assertEquals($expected, $result);
@@ -83,6 +83,33 @@ CONTENT;
         $header = " * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)\n *\n";
         $translation = new LocalText(array(), LocalText::$TYPE_ARRAY, $author, $header);
         $translation->render();
+    }
+
+    public function testLicencewithmore() {
+
+        $expected = <<<'CONTENT'
+<?php
+
+/**
+ * german language file
+ *
+ * @license    GPL 4 (http://www.gnu.org/licenses/gpl.html)
+ *
+ *
+ * @package DokuWiki\lang\de\settings
+ *
+ * @author author <e@ma.il>
+ */
+$lang['key']                   = 'new translated value';
+
+CONTENT;
+
+        $author = new AuthorList();
+        $author->add(new Author('author', 'e@ma.il'));
+        $header = " *\n * german language file\n *\n * @license    GPL 4 (http://www.gnu.org/licenses/gpl.html)\n *\n *\n * @package DokuWiki\\lang\\de\\settings\n";
+        $translation = new LocalText(array('key' => 'new translated value'), LocalText::$TYPE_ARRAY, $author, $header);
+        $result = $translation->render();
+        $this->assertEquals($expected, $result);
     }
 
 }

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LocalTextTest.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/LocalTextTest.php
@@ -85,7 +85,7 @@ CONTENT;
         $translation->render();
     }
 
-    public function testLicencewithmore() {
+    public function testLicencewithmoreAndNoEmails() {
 
         $expected = <<<'CONTENT'
 <?php
@@ -99,6 +99,8 @@ CONTENT;
  * @package DokuWiki\lang\de\settings
  *
  * @author author <e@ma.il>
+ * @author author2
+ * @author author3
  */
 $lang['key']                   = 'new translated value';
 
@@ -106,6 +108,39 @@ CONTENT;
 
         $author = new AuthorList();
         $author->add(new Author('author', 'e@ma.il'));
+        $author->add(new Author('author2', ''));
+        $author->add(new Author('author3', ''));
+        $header = " *\n * german language file\n *\n * @license    GPL 4 (http://www.gnu.org/licenses/gpl.html)\n *\n *\n * @package DokuWiki\\lang\\de\\settings\n";
+        $translation = new LocalText(array('key' => 'new translated value'), LocalText::$TYPE_ARRAY, $author, $header);
+        $result = $translation->render();
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testLicencewithmoreAndNoNames() {
+
+        $expected = <<<'CONTENT'
+<?php
+
+/**
+ * german language file
+ *
+ * @license    GPL 4 (http://www.gnu.org/licenses/gpl.html)
+ *
+ *
+ * @package DokuWiki\lang\de\settings
+ *
+ * @author author <e@ma.il>
+ * @author e1 <e1@ma.il>
+ * @author e2 <e2@ma.il>
+ */
+$lang['key']                   = 'new translated value';
+
+CONTENT;
+
+        $author = new AuthorList();
+        $author->add(new Author('author', 'e@ma.il'));
+        $author->add(new Author('', 'e1@ma.il'));
+        $author->add(new Author('', 'e2@ma.il'));
         $header = " *\n * german language file\n *\n * @license    GPL 4 (http://www.gnu.org/licenses/gpl.html)\n *\n *\n * @package DokuWiki\\lang\\de\\settings\n";
         $translation = new LocalText(array('key' => 'new translated value'), LocalText::$TYPE_ARRAY, $author, $header);
         $result = $translation->render();

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/testLang.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/testLang.php
@@ -21,6 +21,9 @@
  * @author Matthias Schulte <mailinglist@lupo49.de>
  * @author Paul Lachewsky <kaeptn.haddock@gmail.com>
  * @author Pierre Corell <info@joomla-praxis.de>
+ *
+ *
+ * @package DokuWiki\lang\de\settings
  */
 $lang['encoding']              = 'utf-8';
 $lang['direction']             = 'ltr';

--- a/src/org/dokuwiki/translatorBundle/Tests/Services/Language/testLang.php
+++ b/src/org/dokuwiki/translatorBundle/Tests/Services/Language/testLang.php
@@ -21,6 +21,8 @@
  * @author Matthias Schulte <mailinglist@lupo49.de>
  * @author Paul Lachewsky <kaeptn.haddock@gmail.com>
  * @author Pierre Corell <info@joomla-praxis.de>
+ * @author Name Surname
+ * @author <info@test2.de>
  *
  *
  * @package DokuWiki\lang\de\settings


### PR DESCRIPTION
- minor improvement for naming/description cli commands
- improve handling zero english translations
- phpdocs
- add page to show settings, and request a one-time edit url
- add page to edit settings. Only one successful save. Implements #19
- if git clone url or branch modified, delete local repository, so that it can be cloned again.
- improve author parsing, e.g. https://github.com/splitbrain/dokuwiki/pull/2211/files
