### PR TITLE
Show number of open pull requests above translation form

### DIFF
--- a/src/org/dokuwiki/translatorBundle/Controller/TranslationController.php
+++ b/src/org/dokuwiki/translatorBundle/Controller/TranslationController.php
@@ -202,6 +202,7 @@ class TranslationController extends Controller implements InitializableControlle
             }
         }
 
+        $data['openPR'] = $this->getOpenPRlistInfo($repositoryEntity, $data['targetLanguage']);
         $data['captcha'] = $this->getCaptchaForm()->createView();
 
         return $this->render('dokuwikiTranslatorBundle:Translate:translate.html.twig', $data);
@@ -242,6 +243,19 @@ class TranslationController extends Controller implements InitializableControlle
      */
     private function getLanguageNameEntityRepository() {
         return $this->entityManager->getRepository('dokuwikiTranslatorBundle:LanguageNameEntity');
+    }
+
+    /**
+     * Get information about the open pull requests of the given language
+     *
+     * @param $repositoryEntity
+     * @param $languageNameEntity
+     * @return array with string listURL and int count
+     */
+    private function getOpenPRlistInfo($repositoryEntity, $languageNameEntity) {
+        $repositoryManager = $this->getRepositoryManager();
+        $repository = $repositoryManager->getRepository($repositoryEntity);
+        return $repository->getOpenPRlistInfo($languageNameEntity);
     }
 
     /**

--- a/src/org/dokuwiki/translatorBundle/Resources/views/Translate/translate.html.twig
+++ b/src/org/dokuwiki/translatorBundle/Resources/views/Translate/translate.html.twig
@@ -32,8 +32,29 @@
                 </p>
                 <p>
                     When you're done click the submit button. Your changes will be automatically submitted to the developers.
-                    You can find your changes <a href="https://github.com/dokuwiki-translate">here</a>.
+                    {% if openPR.count == 0 %}
+                        {% if openPR.listURL == '' %}
+                            You can find your changes <a href="https://github.com/dokuwiki-translate?tab=repositories">here</a>.
+                        {% else %}
+                            You can find previous {{ targetLanguage.name }} translation submissions
+                            <a href="{{ openPR.listURL }}">here</a>.
+                        {% endif %}
+                    {% endif %}
                 </p>
+
+                {% if openPR.count > 0 %}
+                    <div class="alert alert-info">
+                        <button type="button" class="close" data-dismiss="alert">&times;</button>
+                        There
+                        {% if openPR.count == 1%}
+                            is <b>1 translation</b>
+                        {% else %}
+                            are <b>{{ openPR.count }} translations</b>
+                        {% endif %}
+                        not merged for the {{ targetLanguage.name }} translation of the {{ repository.displayName }}.
+                        You can find open submissions at <a href="{{ openPR.listURL }}">GitHub</a>.
+                    </div>
+                {% endif %}
 
                 <h2>{{ targetLanguage.name }} translation</h2>
 

--- a/src/org/dokuwiki/translatorBundle/Services/GitHub/GitHubService.php
+++ b/src/org/dokuwiki/translatorBundle/Services/GitHub/GitHubService.php
@@ -83,4 +83,33 @@ class GitHubService {
         }
     }
 
+    /**
+     * Get information about the open pull requests i.e. url and count
+     *
+     * @param string $url remote url
+     * @param string $languageCode
+     *
+     * @return array
+     */
+    public function getOpenPRlistInfo($url, $languageCode) {
+        list($user, $repository) = $this->getUsernameAndRepositoryFromURL($url);
+
+        $info = [
+            'listURL' => '',
+            'count' => 0
+        ];
+
+        try {
+            $q = 'Translation update ('.$languageCode.') in:title repo:'.$user.'/'.$repository.' type:pr state:open';
+            $results = $this->client->api('search')->issues($q, $sort = 'updated', $order = 'desc');
+
+            $info = [
+                'listURL' => 'https://github.com/'.$user.'/'.$repository.'/pulls?q=is%3Apr+is%3Aopen+Translation+update+%28'.$languageCode.'%29',
+                'count' => (int) $results['total_count']
+            ];
+        } catch (\Exception $e) {
+        }
+
+        return $info;
+    }
 }

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/GitHubBehavior.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/GitHubBehavior.php
@@ -2,6 +2,7 @@
 
 namespace org\dokuwiki\translatorBundle\Services\Repository\Behavior;
 
+use org\dokuwiki\translatorBundle\Entity\LanguageNameEntity;
 use org\dokuwiki\translatorBundle\Entity\RepositoryEntity;
 use org\dokuwiki\translatorBundle\Entity\TranslationUpdateEntity;
 use org\dokuwiki\translatorBundle\Services\Git\GitRepository;
@@ -20,7 +21,7 @@ class GitHubBehavior implements RepositoryBehavior {
      */
     private $gitHubService;
 
-    function __construct(GitHubService $api, GitHubStatusService $gitHubStatus) {
+    public function __construct(GitHubService $api, GitHubStatusService $gitHubStatus) {
         $this->api = $api;
         $this->gitHubService = $gitHubStatus;
     }
@@ -32,7 +33,7 @@ class GitHubBehavior implements RepositoryBehavior {
      * @param TranslationUpdateEntity $update
      * @param GitRepository $originalGit
      */
-    function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit) {
+    public function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit) {
 
         $remoteUrl = $originalGit->getRemoteUrl();
         $tempGit->remoteAdd('github', $remoteUrl);
@@ -52,7 +53,7 @@ class GitHubBehavior implements RepositoryBehavior {
      * @param RepositoryEntity $repository
      * @return string Git URL of the fork
      */
-    function createOriginURL(RepositoryEntity $repository) {
+    public function createOriginURL(RepositoryEntity $repository) {
         return $this->api->createFork($repository->getUrl());
     }
 
@@ -63,7 +64,7 @@ class GitHubBehavior implements RepositoryBehavior {
      * @param RepositoryEntity $repository
      * @return bool true if the repository is changed
      */
-    function pull(GitRepository $git, RepositoryEntity $repository) {
+    public function pull(GitRepository $git, RepositoryEntity $repository) {
         $changed = $git->pull($repository->getUrl(), $repository->getBranch()) === GitRepository::$PULL_CHANGED;
         $git->push('origin', $repository->getBranch());
         return $changed;
@@ -72,7 +73,18 @@ class GitHubBehavior implements RepositoryBehavior {
     /**
      * @return bool|null
      */
-    function isFunctional() {
+    public function isFunctional() {
         return $this->gitHubService->isFunctional();
+    }
+
+    /**
+     * Get information about the open pull requests i.e. url and count
+     *
+     * @param RepositoryEntity $repository
+     * @param LanguageNameEntity $language
+     * @return array
+     */
+    public function getOpenPRlistInfo(RepositoryEntity $repository, LanguageNameEntity $language) {
+        return $this->api->getOpenPRlistInfo($repository->getUrl(), $language->getCode());
     }
 }

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/PlainBehavior.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/PlainBehavior.php
@@ -2,6 +2,7 @@
 
 namespace org\dokuwiki\translatorBundle\Services\Repository\Behavior;
 
+use org\dokuwiki\translatorBundle\Entity\LanguageNameEntity;
 use org\dokuwiki\translatorBundle\Entity\RepositoryEntity;
 use org\dokuwiki\translatorBundle\Entity\TranslationUpdateEntity;
 use org\dokuwiki\translatorBundle\Services\Git\GitRepository;
@@ -14,12 +15,12 @@ class PlainBehavior implements RepositoryBehavior {
      */
     private $mailService;
 
-    function __construct($mailService) {
+    public function __construct($mailService) {
         $this->mailService = $mailService;
     }
 
 
-    function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit) {
+    public function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit) {
         $patch = $tempGit->createPatch();
 
         $this->mailService->sendPatchEmail(
@@ -37,7 +38,7 @@ class PlainBehavior implements RepositoryBehavior {
      * @param RepositoryEntity $repository
      * @return string
      */
-    function createOriginURL(RepositoryEntity $repository) {
+    public function createOriginURL(RepositoryEntity $repository) {
         return $repository->getUrl();
     }
 
@@ -48,11 +49,25 @@ class PlainBehavior implements RepositoryBehavior {
      * @param RepositoryEntity $repository
      * @return bool true if the repository is changed
      */
-    function pull(GitRepository $git, RepositoryEntity $repository) {
+    public function pull(GitRepository $git, RepositoryEntity $repository) {
         return $git->pull('origin', $repository->getBranch()) === GitRepository::$PULL_CHANGED;
     }
 
-    function isFunctional() {
+    public function isFunctional() {
         return true;
+    }
+
+    /**
+     * Get information about the open pull requests i.e. url and count
+     *
+     * @param RepositoryEntity $repository
+     * @param LanguageNameEntity $language
+     * @return array
+     */
+    public function getOpenPRlistInfo(RepositoryEntity $repository, LanguageNameEntity $language) {
+        return array(
+            'count' => 0,
+            'listURL' => ''
+        );
     }
 }

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/RepositoryBehavior.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Behavior/RepositoryBehavior.php
@@ -2,13 +2,14 @@
 
 namespace org\dokuwiki\translatorBundle\Services\Repository\Behavior;
 
+use org\dokuwiki\translatorBundle\Entity\LanguageNameEntity;
 use org\dokuwiki\translatorBundle\Entity\RepositoryEntity;
 use org\dokuwiki\translatorBundle\Entity\TranslationUpdateEntity;
 use org\dokuwiki\translatorBundle\Services\Git\GitRepository;
 
 interface RepositoryBehavior {
 
-    function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit);
+    public function sendChange(GitRepository $tempGit, TranslationUpdateEntity $update, GitRepository $originalGit);
 
     /**
      * Return url of 'origin' repository
@@ -18,7 +19,7 @@ interface RepositoryBehavior {
      * @param RepositoryEntity $repository
      * @return string
      */
-    function createOriginURL(RepositoryEntity $repository);
+    public function createOriginURL(RepositoryEntity $repository);
 
     /**
      * Update repository from remote
@@ -27,9 +28,17 @@ interface RepositoryBehavior {
      * @param RepositoryEntity $repository
      * @return bool true if the repository is changed
      */
-    function pull(GitRepository $git, RepositoryEntity $repository);
+    public function pull(GitRepository $git, RepositoryEntity $repository);
 
 
-    function isFunctional();
+    public function isFunctional();
 
+    /**
+     * Get information about the open pull requests i.e. url and count
+     *
+     * @param RepositoryEntity $repository
+     * @param LanguageNameEntity $language
+     * @return array
+     */
+    public function getOpenPRlistInfo(RepositoryEntity $repository, LanguageNameEntity $language);
 }

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/Repository.php
@@ -3,6 +3,7 @@ namespace org\dokuwiki\translatorBundle\Services\Repository;
 
 use Github\Exception\RuntimeException;
 use Monolog\Logger;
+use org\dokuwiki\translatorBundle\Entity\LanguageNameEntity;
 use org\dokuwiki\translatorBundle\Services\Git\GitAddException;
 use org\dokuwiki\translatorBundle\Services\Git\GitBranchException;
 use org\dokuwiki\translatorBundle\Services\Git\GitCheckoutException;
@@ -493,6 +494,16 @@ abstract class Repository {
      */
     public function hasGit() {
         return is_dir($this->getCloneDirectoryPath());
+    }
+
+    /**
+     * Get information about the open pull requests i.e. url and count
+     *
+     * @param LanguageNameEntity $languageNameEntity
+     * @return array with count and list url
+     */
+    public function getOpenPRlistInfo(LanguageNameEntity $languageNameEntity) {
+        return $this->behavior->getOpenPRlistInfo($this->entity, $languageNameEntity);
     }
 
     /**

--- a/src/org/dokuwiki/translatorBundle/Services/Repository/RepositoryStats.php
+++ b/src/org/dokuwiki/translatorBundle/Services/Repository/RepositoryStats.php
@@ -45,7 +45,7 @@ class RepositoryStats {
     public function createStats($translations, RepositoryEntity $repository) {
         $scores = array();
         if (!isset($translations['en'])) {
-            echo 'none created';
+            echo 'none created ';
             return;
         }
 
@@ -54,7 +54,7 @@ class RepositoryStats {
         }
 
         if($scores['en'] === 0 ) {
-            echo 'zero English strings available';
+            echo 'zero English strings available ';
             return;
         }
 


### PR DESCRIPTION
Show msg above translation form with number of open PRs for current lang 
Improves #85

Also add url to GitHub of the list of open PR requests for the displayed
extension and language.

