### PR TITLE
Add language code to commit message

### DIFF
--- a/src/Services/Repository/Repository.php
+++ b/src/Services/Repository/Repository.php
@@ -500,8 +500,9 @@ abstract class Repository
         // add files to local temporary git repository
         $this->applyChanges($tmpGit, $tmpDir, $update);
         // commit files to local temporary git repository
+        $message = 'Translation update (' . $update->getLanguage() . ')';
         $author = $this->prepareAuthor($update);
-        $tmpGit->commit('translation update', $author);
+        $tmpGit->commit($message, $author);
 
         $this->behavior->sendChange($tmpGit, $update, $this->git);
     }


### PR DESCRIPTION
Before this, the commit message was just `translation update`. now it includes the language code, i.e. `Translation update (xx)`.

Fixes #127 
